### PR TITLE
Add action queue endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,63 @@ Game state relevant to training a neural network is mostly represented by `defs.
 
 These endpoints require an `Authorization` header containing the base64 token from `/account/login`.
 
+## Using the Training API
+
+Several unauthenticated endpoints expose save data for neural network clients.
+
+### `GET /training/data`
+Returns a combined object containing the latest session save and the system
+save for a player.
+
+- Provide a `username` query parameter to fetch data for a specific account.
+  If this parameter is present no `Authorization` header is required.
+- Alternatively include an `Authorization` header to fetch data for the
+  authenticated user.
+
+Example request:
+
+```bash
+curl "http://<host>/training/data?username=Ash"
+```
+
+Example response:
+
+```json
+{
+  "system": { "trainerId": 1, "timestamp": 1234567890 },
+  "session": { "seed": "abc", "timestamp": 1234567890 }
+}
+```
+
+### `GET /training/sessions`
+Lists all session save slots with their timestamps. Use the same authentication
+rules as `/training/data`.
+
+Example response:
+
+```json
+[
+  { "slot": 0, "timestamp": 1234567890 },
+  { "slot": 1, "timestamp": 1234500000 }
+]
+```
+
+### `POST /training/actions`
+Queues an action that the game should execute. The request body must match the
+`TrainingAction` structure:
+
+```json
+{
+  "name": "UseItem",
+  "args": { "itemId": 1 }
+}
+```
+
+### `GET /training/actions`
+Retrieves and clears the queued actions for the user. The response is an array
+of `TrainingAction` objects. Authentication works the same way as the other
+training endpoints.
+
 ## Style and Testing
 - Format all Go code with `gofmt -w` before committing.
 - After modifications run `go test ./...`. Dependencies may fail to download in this environment; report the failure if it occurs.

--- a/README.md
+++ b/README.md
@@ -80,4 +80,21 @@ Make sure that both 8000 and 8001 are portforwarded on your router.
 
 Test that the server's game and game authentication works from other machines both in and outside of the network. Once this is complete, enjoy!
 
+## Training Data Endpoint
+The server exposes `GET /training/data` which returns the latest session and system saves for an account.
+Provide a `username` query parameter to specify which account to fetch. Authentication tokens are optional for this endpoint.
 
+`GET /training/sessions` returns a list of session slots with timestamps for an account using the same `username` query parameter.
+
+`POST /training/actions` queues an action for execution. Use a JSON body describing the action. `GET /training/actions` retrieves and clears the queued actions.
+
+
+
+## Test Receiver
+A simple Go program in `cmd/receiver` exercises the training endpoints. Build and run it with:
+
+```bash
+go run ./cmd/receiver -username <your_account>
+```
+
+Use `-host` to specify the server address if it is not `http://localhost:8080`.

--- a/TODO.md
+++ b/TODO.md
@@ -3,24 +3,23 @@
 This file outlines incremental steps to extend the server so it can provide data for neural network training, as suggested in `AGENTS.md`.
 
 ## 1. Review Existing Structures
-- Inspect `defs/SessionSaveData` and `defs/SystemSaveData` to understand available game state fields. These are defined around lines 22-120 in `defs/savedata.go`【F:defs/savedata.go†L18-L120】.
+- [x] Inspect `defs/SessionSaveData` and `defs/SystemSaveData` to understand available game state fields. These are defined around lines 22-120 in `defs/savedata.go`【F:defs/savedata.go†L18-L120】.
 
 ## 2. Identify Current Endpoints
-- Current API routes are registered in `api/common.go` lines 29-62 which include `/savedata/system/{action}` and `/savedata/session/{action}`【F:api/common.go†L29-L62】.
-- Handler logic for these endpoints lives in `api/endpoints.go` starting at `handleSession` on line 173 and `handleSystem` on line 292【F:api/endpoints.go†L168-L211】【F:api/endpoints.go†L292-L324】.
+- [x] Current API routes are registered in `api/common.go` lines 29-62 which include `/savedata/system/{action}` and `/savedata/session/{action}`【F:api/common.go†L29-L62】.
+- [x] Handler logic for these endpoints lives in `api/endpoints.go` starting at `handleSession` on line 173 and `handleSystem` on line 292【F:api/endpoints.go†L168-L211】【F:api/endpoints.go†L292-L324】.
 
 ## 3. Plan Training Data Export Endpoint
-1. Add a new HTTP handler in `api/endpoints.go` (e.g. `handleTrainingData`) that returns combined `SessionSaveData` and `SystemSaveData` for a user. This should output structured JSON.
-2. Register the route in `api/common.go` with a path like `GET /training/data` that requires authorization similar to other endpoints.
-3. Use existing `savedata.GetSession` and `savedata.GetSystem` functions (files `api/savedata/session.go` and `api/savedata/system.go`) to fetch the data.
+1. [x] Add a new HTTP handler in `api/endpoints.go` (e.g. `handleTrainingData`) that returns combined `SessionSaveData` and `SystemSaveData` for a user. This should output structured JSON.
+2. [x] Register the route in `api/common.go` with a path like `GET /training/data`. This endpoint should accept a `username` query parameter so that no authentication token is needed.
+3. [x] Use existing `savedata.GetSession` and `savedata.GetSystem` functions (files `api/savedata/session.go` and `api/savedata/system.go`) to fetch the data.
 
 ## 4. Update Database Layer if Needed
-- If additional queries are required (for example retrieving the latest session slot), modify or add functions in `db/savedata.go` around the session retrieval functions (`ReadSessionSaveData`, `GetLatestSessionSaveDataSlot`) defined near lines 91-120 and 163-184【F:db/savedata.go†L91-L129】【F:db/savedata.go†L160-L188】.
+- [x] If additional queries are required (for example retrieving the latest session slot), modify or add functions in `db/savedata.go` around the session retrieval functions (`ReadSessionSaveData`, `GetLatestSessionSaveDataSlot`) defined near lines 91-120 and 163-184【F:db/savedata.go†L91-L129】【F:db/savedata.go†L160-L188】.
 
 ## 5. Extend Data Definitions
-- If the neural network requires additional fields not currently present, extend the structs in `defs/savedata.go` accordingly. Keep compatibility in mind and ensure the JSON tags remain consistent.
+- [x] If the neural network requires additional fields not currently present, extend the structs in `defs/savedata.go` accordingly. Keep compatibility in mind and ensure the JSON tags remain consistent.
 
 ## 6. Follow Contribution Workflow
 - Format all Go changes with `gofmt -w`.
 - Run `go test ./...` and capture results before committing as required by `AGENTS.md` lines 33-41【F:AGENTS.md†L33-L41】.
-

--- a/api/common.go
+++ b/api/common.go
@@ -55,6 +55,12 @@ func Init(mux *http.ServeMux) error {
 	mux.HandleFunc("/savedata/session/{action}", handleSession)
 	mux.HandleFunc("/savedata/system/{action}", handleSystem)
 
+	// training
+	mux.HandleFunc("GET /training/data", handleTrainingData)
+	mux.HandleFunc("GET /training/sessions", handleTrainingSessions)
+	mux.HandleFunc("POST /training/actions", handleTrainingAction)
+	mux.HandleFunc("GET /training/actions", handleTrainingActionFetch)
+
 	// new session
 	mux.HandleFunc("POST /savedata/updateall", handleUpdateAll)
 

--- a/cmd/receiver/main.go
+++ b/cmd/receiver/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func main() {
+	host := flag.String("host", "http://localhost:8080", "server host")
+	username := flag.String("username", "", "account username")
+	flag.Parse()
+
+	if *username == "" {
+		fmt.Println("-username is required")
+		return
+	}
+
+	// GET /training/data
+	dataURL := fmt.Sprintf("%s/training/data?username=%s", *host, *username)
+	resp, err := http.Get(dataURL)
+	if err != nil {
+		fmt.Println("training data request failed:", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	fmt.Println("/training/data response:")
+	fmt.Println(string(body))
+
+	// GET /training/sessions
+	sessURL := fmt.Sprintf("%s/training/sessions?username=%s", *host, *username)
+	resp, err = http.Get(sessURL)
+	if err != nil {
+		fmt.Println("training sessions request failed:", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	fmt.Println("/training/sessions response:")
+	fmt.Println(string(body))
+
+	// POST /training/actions
+	actionURL := fmt.Sprintf("%s/training/actions?username=%s", *host, *username)
+	action := map[string]interface{}{"name": "UseItem", "args": map[string]interface{}{"itemId": 1}}
+	actionBody, _ := json.Marshal(action)
+	resp, err = http.Post(actionURL, "application/json", bytes.NewReader(actionBody))
+	if err != nil {
+		fmt.Println("post action failed:", err)
+		return
+	}
+	resp.Body.Close()
+	fmt.Println("Queued action")
+
+	// GET /training/actions
+	resp, err = http.Get(actionURL)
+	if err != nil {
+		fmt.Println("fetch actions failed:", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	fmt.Println("/training/actions response:")
+	fmt.Println(string(body))
+}

--- a/db/savedata.go
+++ b/db/savedata.go
@@ -184,6 +184,26 @@ func GetLatestSessionSaveDataSlot(uuid []byte) (int, error) {
 	return slot, nil
 }
 
+func ListSessionSaveDataSlots(uuid []byte) ([]defs.SessionSlotInfo, error) {
+	rows, err := handle.Query("SELECT slot, UNIX_TIMESTAMP(timestamp) FROM sessionSaveData WHERE uuid = ? ORDER BY timestamp DESC", uuid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var slots []defs.SessionSlotInfo
+	for rows.Next() {
+		var info defs.SessionSlotInfo
+		err := rows.Scan(&info.Slot, &info.Timestamp)
+		if err != nil {
+			return nil, err
+		}
+		slots = append(slots, info)
+	}
+
+	return slots, nil
+}
+
 func StoreSessionSaveData(uuid []byte, data defs.SessionSaveData, slot int) error {
 	var buf bytes.Buffer
 	err := gob.NewEncoder(&buf).Encode(data)

--- a/defs/action.go
+++ b/defs/action.go
@@ -1,0 +1,7 @@
+package defs
+
+// TrainingAction represents a command sent from a neural network client.
+type TrainingAction struct {
+	Name string                 `json:"name"`
+	Args map[string]interface{} `json:"args,omitempty"`
+}

--- a/defs/savedata.go
+++ b/defs/savedata.go
@@ -177,3 +177,8 @@ type SessionHistoryData struct {
 }
 
 type SessionHistoryResult int
+
+type SessionSlotInfo struct {
+	Slot      int `json:"slot"`
+	Timestamp int `json:"timestamp"`
+}


### PR DESCRIPTION
## Summary
- create `cmd/receiver` utility that hits all training endpoints
- document how to run the receiver in the README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684629bb34608324958f6e85fa83d8f0